### PR TITLE
switch underlying implementations to be const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/frewsxcv/rust-gcd"
 documentation = "https://docs.rs/gcd/"
 categories = ["algorithms"]
 
+[dependencies]
+paste = "1"
+
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,27 +111,143 @@ gcd_impl! { u8, u16, u32, u64, u128, usize }
 mod test {
     use super::*;
 
-    #[test]
-    fn test_gcd() {
-        assert_eq!(0, 0u8.gcd_euclid(0));
-        assert_eq!(10, 10u8.gcd_euclid(0));
-        assert_eq!(10, 0u8.gcd_euclid(10));
-        assert_eq!(10, 10u8.gcd_euclid(20));
-        assert_eq!(44, 2024u32.gcd_euclid(748));
+    const U8_GCD_A: [u8; 5] = [140, 1, 140, 33, 225];
+    const U8_GCD_B: [u8; 5] = [136, 123, 203, 252, 153];
+    const U8_GCD_R: [u8; 5] = [4, 1, 7, 3, 9];
 
-        assert_eq!(0, 0u8.gcd_binary(0));
-        assert_eq!(10, 10u8.gcd_binary(0));
-        assert_eq!(10, 0u8.gcd_binary(10));
-        assert_eq!(10, 10u8.gcd_binary(20));
-        assert_eq!(44, 2024u32.gcd_binary(748));
+    const U16_GCD_A: [u16; 5] = [53144, 44062, 65054, 60568, 11932];
+    const U16_GCD_B: [u16; 5] = [41105, 5088, 35332, 19184, 54004];
+    const U16_GCD_R: [u16; 5] = [1, 2, 22, 8, 4];
+
+    const U32_GCD_A: [u32; 5] = [3392079986, 273672341, 1353048788, 1491301950, 3569727686];
+    const U32_GCD_B: [u32; 5] = [2080089626, 3912533700, 1969135932, 1356732645, 58056677];
+    const U32_GCD_R: [u32; 5] = [2, 1, 4, 15, 7];
+
+    const U64_GCD_A: [u64; 5] = [
+        190266297176832000,
+        2040134905096275968,
+        16611311494648745984,
+        14863931409971066880,
+        11777713923171739648,
+    ];
+    const U64_GCD_B: [u64; 5] = [
+        10430732356495263744,
+        5701159354248194048,
+        7514969329383038976,
+        7911906750992527360,
+        1994469765110767616,
+    ];
+    const U64_GCD_R: [u64; 5] = [6144, 2048, 4096, 10240, 14336];
+
+    const U128_GCD_A: [u128; 5] = [
+        183222947567111613556380400704880115712,
+        115621006611964852903362423926779019264,
+        50724538437787115589243518273596686336,
+        18298803717624646317403958239767298048,
+        196929845599653749349770751890136498176,
+    ];
+    const U128_GCD_B: [u128; 5] = [
+        283620717889381409474181015983148236800,
+        152390035351551984363917166384150216704,
+        74996138554240857099554660445327458304,
+        245604784002268488089190010796573196288,
+        194671916188106984823441978656659865600,
+    ];
+    const U128_GCD_R: [u128; 5] = [
+        37778931862957161709568,
+        75557863725914323419136,
+        113336795588871485128704,
+        151115727451828646838272,
+        302231454903657293676544,
+    ];
+
+    const USIZE_GCD_A: [usize; 5] = [335286345, 3125888386, 3550412466, 924335944, 2870209473];
+    const USIZE_GCD_B: [usize; 5] = [1843742025, 2080426243, 16052620, 1587387560, 24708111];
+    const USIZE_GCD_R: [usize; 5] = [15, 1, 2, 8, 3];
+
+    #[test]
+    fn test_gcd_basic() {
+        // some base cases
+        assert_eq!(0, 0u8.gcd(0));
+        assert_eq!(10, 10u8.gcd(0));
+        assert_eq!(10, 0u8.gcd(10));
     }
 
-    const GCD_10_20: u16 = binary_u16(10, 20);
-    const GCD_2024_748: u32 = binary_u32(2024, 44);
+    #[test]
+    fn test_gcd() {
+        // u8
+        for (ind, val) in U8_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(U8_GCD_B[ind]);
+            let egcd = val.gcd_euclid(U8_GCD_B[ind]);
+            let bgcd = val.gcd_binary(U8_GCD_B[ind]);
+            assert_eq!(U8_GCD_R[ind], gcd);
+            assert_eq!(U8_GCD_R[ind], bgcd);
+            assert_eq!(U8_GCD_R[ind], egcd);
+        }
+
+        // u16
+        for (ind, val) in U16_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(U16_GCD_B[ind]);
+            let egcd = val.gcd_euclid(U16_GCD_B[ind]);
+            let bgcd = val.gcd_binary(U16_GCD_B[ind]);
+            assert_eq!(U16_GCD_R[ind], gcd);
+            assert_eq!(U16_GCD_R[ind], bgcd);
+            assert_eq!(U16_GCD_R[ind], egcd);
+        }
+
+        // u32
+        for (ind, val) in U32_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(U32_GCD_B[ind]);
+            let egcd = val.gcd_euclid(U32_GCD_B[ind]);
+            let bgcd = val.gcd_binary(U32_GCD_B[ind]);
+            assert_eq!(U32_GCD_R[ind], gcd);
+            assert_eq!(U32_GCD_R[ind], bgcd);
+            assert_eq!(U32_GCD_R[ind], egcd);
+        }
+
+        // u64
+        for (ind, val) in U64_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(U64_GCD_B[ind]);
+            let egcd = val.gcd_euclid(U64_GCD_B[ind]);
+            let bgcd = val.gcd_binary(U64_GCD_B[ind]);
+            assert_eq!(U64_GCD_R[ind], gcd);
+            assert_eq!(U64_GCD_R[ind], bgcd);
+            assert_eq!(U64_GCD_R[ind], egcd);
+        }
+
+        // u128
+        for (ind, val) in U128_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(U128_GCD_B[ind]);
+            let egcd = val.gcd_euclid(U128_GCD_B[ind]);
+            let bgcd = val.gcd_binary(U128_GCD_B[ind]);
+            assert_eq!(U128_GCD_R[ind], gcd);
+            assert_eq!(U128_GCD_R[ind], bgcd);
+            assert_eq!(U128_GCD_R[ind], egcd);
+        }
+
+        // usize
+        for (ind, val) in USIZE_GCD_A.iter().enumerate() {
+            let gcd = val.gcd(USIZE_GCD_B[ind]);
+            let egcd = val.gcd_euclid(USIZE_GCD_B[ind]);
+            let bgcd = val.gcd_binary(USIZE_GCD_B[ind]);
+            assert_eq!(USIZE_GCD_R[ind], gcd);
+            assert_eq!(USIZE_GCD_R[ind], bgcd);
+            assert_eq!(USIZE_GCD_R[ind], egcd);
+        }
+    }
+
+    const U32_GCD_R_0: u32 = binary_u32(U32_GCD_A[0], U32_GCD_B[0]);
+    const U32_GCD_R_1: u32 = euclid_u32(U32_GCD_A[1], U32_GCD_B[1]);
+    const U32_GCD_R_2: u32 = binary_u32(U32_GCD_A[2], U32_GCD_B[2]);
+    const U32_GCD_R_3: u32 = euclid_u32(U32_GCD_A[3], U32_GCD_B[3]);
+    const U32_GCD_R_4: u32 = binary_u32(U32_GCD_A[4], U32_GCD_B[4]);
 
     #[test]
     fn test_const_gcd() {
-        assert_eq!(10, GCD_10_20);
-        assert_eq!(44, GCD_2024_748);
+        assert_eq!(U32_GCD_R[0], U32_GCD_R_0);
+        assert_eq!(U32_GCD_R[1], U32_GCD_R_1);
+        assert_eq!(U32_GCD_R[2], U32_GCD_R_2);
+        assert_eq!(U32_GCD_R[3], U32_GCD_R_3);
+        assert_eq!(U32_GCD_R[4], U32_GCD_R_4);
     }
 }


### PR DESCRIPTION
Switches the underlying implementations to `const` functions. Introduces one dependency `paste`, but that dependency is lightweight and does not depend on any other crates.

Performance varied run to run and seems to be mixed - likely the same:
```
gcd euclid u8           time:   [3.2160 us 3.2167 us 3.2176 us]
                        change: [-0.6447% -0.3519% +0.0137%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

gcd euclid u16          time:   [11.442 us 11.951 us 12.500 us]
                        change: [+11.083% +15.276% +19.478%] (p = 0.00 < 0.05)
                        Performance has regressed.

gcd euclid u32          time:   [35.032 us 35.660 us 36.440 us]
                        change: [-17.284% -15.774% -14.371%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

gcd euclid u64          time:   [141.15 us 141.17 us 141.20 us]
                        change: [-0.8611% -0.6959% -0.5280%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

gcd euclid u128         time:   [585.27 us 585.39 us 585.53 us]
                        change: [+0.2489% +0.4114% +0.5738%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

gcd binary u8           time:   [7.0149 us 7.0188 us 7.0240 us]
                        change: [-4.6293% -3.5618% -2.4328%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

gcd binary u16          time:   [19.059 us 19.145 us 19.255 us]
                        change: [+3.7772% +4.7257% +5.6026%] (p = 0.00 < 0.05)
                        Performance has regressed.

gcd binary u32          time:   [42.927 us 42.992 us 43.074 us]
                        change: [-4.0189% -3.7625% -3.5128%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

gcd binary u64          time:   [95.513 us 95.527 us 95.540 us]
                        change: [+0.7879% +0.9451% +1.0859%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

gcd binary u128         time:   [502.06 us 502.11 us 502.18 us]
                        change: [-0.9236% -0.7319% -0.5519%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
```

Closes #8 