### PR TITLE
Add nonzero versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,14 +84,17 @@ macro_rules! gcd_impl {
         }
 
         impl Gcd for $T {
+            #[inline]
             fn gcd(self, other: $T) -> $T {
                 self.gcd_binary(other)
             }
 
+            #[inline]
             fn gcd_binary(self, v: $T) -> $T {
                 $binary(self, v)
             }
 
+            #[inline]
             fn gcd_euclid(self, other: $T) -> $T {
                 $euclid(self, other)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,62 +30,58 @@ pub trait Gcd {
 
 macro_rules! gcd_impl {
     ($(($T:ty) $binary:ident $euclid:ident),*) => {$(
+        #[doc = concat!("Const binary GCD implementation for `", stringify!($T), "`.")]
+        pub const fn $binary(mut u: $T, mut v: $T) -> $T
+        {
+            if u == 0 { return v; }
+            if v == 0 { return u; }
 
+            let shift = (u | v).trailing_zeros();
+            u >>= shift;
+            v >>= shift;
+            u >>= u.trailing_zeros();
 
-            #[doc = concat!("Const binary GCD implementation for `", stringify!($T), "`.")]
-            pub const fn $binary(mut u: $T, mut v: $T) -> $T
-            {
-                if u == 0 { return v; }
-                if v == 0 { return u; }
-
-                let shift = (u | v).trailing_zeros();
-                u >>= shift;
-                v >>= shift;
-                u >>= u.trailing_zeros();
-
-                loop {
-                    v >>= v.trailing_zeros();
-
-                    #[allow(clippy::manual_swap)]
-                    if u > v {
-                        // mem::swap(&mut u, &mut v);
-                        let temp = u;
-                        u = v;
-                        v = temp;
-                    }
-
-                    v -= u; // here v >= u
-
-                    if v == 0 { break; }
-                }
-
-                u << shift
-            }
-
-            #[doc = concat!("Const euclid GCD implementation for `", stringify!($T), "`.")]
-            pub const fn $euclid( a: $T,  b: $T) -> $T
-            {
-                // variable names based off euclidean division equation: a = b · q + r
-                let (mut a, mut b) = if a > b {
-                    (a, b)
-                } else {
-                    (b, a)
-                };
+            loop {
+                v >>= v.trailing_zeros();
 
                 #[allow(clippy::manual_swap)]
-                while b != 0 {
-                    // mem::swap(&mut a, &mut b);
-                    let temp = a;
-                    a = b;
-                    b = temp;
-
-                    b %= a;
+                if u > v {
+                    // mem::swap(&mut u, &mut v);
+                    let temp = u;
+                    u = v;
+                    v = temp;
                 }
 
-                a
+                v -= u; // here v >= u
+
+                if v == 0 { break; }
             }
 
+            u << shift
+        }
 
+        #[doc = concat!("Const euclid GCD implementation for `", stringify!($T), "`.")]
+        pub const fn $euclid(a: $T, b: $T) -> $T
+        {
+            // variable names based off euclidean division equation: a = b · q + r
+            let (mut a, mut b) = if a > b {
+                (a, b)
+            } else {
+                (b, a)
+            };
+
+            #[allow(clippy::manual_swap)]
+            while b != 0 {
+                // mem::swap(&mut a, &mut b);
+                let temp = a;
+                a = b;
+                b = temp;
+
+                b %= a;
+            }
+
+            a
+        }
 
         impl Gcd for $T {
             fn gcd(self, other: $T) -> $T {
@@ -93,15 +89,11 @@ macro_rules! gcd_impl {
             }
 
             fn gcd_binary(self, v: $T) -> $T {
-
-                    $binary(self, v)
-
+                $binary(self, v)
             }
 
             fn gcd_euclid(self, other: $T) -> $T {
-
-                    $euclid(self, other)
-
+                $euclid(self, other)
             }
         }
     )*};


### PR DESCRIPTION
For now, this just wraps the existing zeroable versions for convenience. Knowing this detail, it uses the nonzero versions in testing.

Additionally, I added tests for zero-argument GCDs since I noticed they were missing.

Side note: I chose to go with the safe version of `NonZeroU*::new` + `unreachable!()`, although I have a feeling that the optimiser isn't smart enough to remove the actual test for zero here. Since there was no existing unsafe code in this crate, I decided to keep it safe instead of adding `new_unchecked`.

I personally end up calling the GCD of nonzero types more often than zeroable types, since I use nonzero variants for denominators in rational types.